### PR TITLE
Generate v850 bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ ios32:
 w32:
 	${CCw32} ${CFLAGS} ired.c -o ired.exe
 
+v850:
+	./v850.sh
+
 loc:
 	@wc -l *.c *.h | grep total
 

--- a/cmd.c
+++ b/cmd.c
@@ -213,11 +213,13 @@ static int cmd_resize(char *arg) {
 			}
 			free(buf);
 			if((ret = io_seek(0, SEEK_END))>n)
-				ret = io_truncate(ret-n);
+				//ret = io_truncate(ret-n);
+				ret = 0;
 		} else perror("malloc");
 		break;
 	default:
-		ret = io_truncate(str2ut64(arg));
+		//ret = io_truncate(str2ut64(arg));
+		ret = 0;
 	}
 	if(ret<0) perror("truncate");
 	return 1;

--- a/io.c
+++ b/io.c
@@ -19,7 +19,7 @@ static int io_seek (int x,int y) {
 }
 #define io_close() printf("close: TODO\n")
 #define io_system(x) system(x)
-#define io_truncate(x) printf("truncate: TODO\n");
+//#define io_truncate(x) printf("truncate: TODO\n");
 #else
 #if __WIN32__
 
@@ -61,7 +61,7 @@ static inline int io_open(char *file) {
 #define io_seek(x,y) lseek(_fd, x, y)
 #define io_close() close(_fd)
 #define io_system(x) system(x)
-#define io_truncate(x) ftruncate(_fd, (unsigned long)x)
+//#define io_truncate(x) ftruncate(_fd, (unsigned long)x)
 
 #endif
 #endif

--- a/v850.sh
+++ b/v850.sh
@@ -4,4 +4,4 @@ CC="docker run --rm --volume $(pwd):$(pwd) -w $(pwd) dkulacz/gcc-v850-elf-toolch
 TOOLCHAIN_PREFIX="v850-elf-"
 FLAGS="-mv850e3v5 -mloop -mrh850-abi"
 $CC ${TOOLCHAIN_PREFIX}gcc ${FLAGS} ired.c -o ired_v850
-$CC ${TOOLCHAIN_PREFIX}size --format=berkeley -o ired_v850.elf
+#$CC ${TOOLCHAIN_PREFIX}size --format=berkeley -o ired_v850.elf

--- a/v850.sh
+++ b/v850.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -x
+
+CC="docker run --rm --volume $(pwd):$(pwd) -w $(pwd) dkulacz/gcc-v850-elf-toolchain:latest"
+TOOLCHAIN_PREFIX="v850-elf-"
+FLAGS="-mv850e3v5 -mloop -mrh850-abi"
+$CC ${TOOLCHAIN_PREFIX}gcc ${FLAGS} ired.c -o ired_v850
+$CC ${TOOLCHAIN_PREFIX}size --format=berkeley -o ired_v850.elf

--- a/v850.sh
+++ b/v850.sh
@@ -4,4 +4,4 @@ CC="docker run --rm --volume $(pwd):$(pwd) -w $(pwd) dkulacz/gcc-v850-elf-toolch
 TOOLCHAIN_PREFIX="v850-elf-"
 FLAGS="-mv850e3v5 -mloop -mrh850-abi"
 $CC ${TOOLCHAIN_PREFIX}gcc ${FLAGS} ired.c -o ired_v850
-#$CC ${TOOLCHAIN_PREFIX}size --format=berkeley -o ired_v850.elf
+$CC ${TOOLCHAIN_PREFIX}size --format=berkeley -o ired_v850


### PR DESCRIPTION
Does not support `ftruncate`, so just commented io since it's rarely (never?) found for this MCU I guess.

```shell
$ make v850
./v850.sh
++ pwd
++ pwd
++ pwd
+ CC='docker run --rm --volume /Users/romanvg/Desktop/ecu_mossos/misc/ired:/Users/romanvg/Desktop/ecu_mossos/misc/ired -w /Users/romanvg/Desktop/ecu_mossos/misc/ired dkulacz/gcc-v850-elf-toolchain:latest'
+ TOOLCHAIN_PREFIX=v850-elf-
+ FLAGS='-mv850e3v5 -mloop -mrh850-abi'
+ docker run --rm --volume /Users/romanvg/Desktop/ecu_mossos/misc/ired:/Users/romanvg/Desktop/ecu_mossos/misc/ired -w /Users/romanvg/Desktop/ecu_mossos/misc/ired dkulacz/gcc-v850-elf-toolchain:latest v850-elf-gcc -mv850e3v5 -mloop -mrh850-abi ired.c -o ired_v850


$ file ired_v850
ired_v850: ELF 32-bit LSB executable, NEC V800 or cisco 12000, version 1 (SYSV), statically linked, with debug_info, not stripped

$ r2 -version
radare2 4.6.0-git 25154 @ darwin-x86-64 git.4.1.1-1555-gaf337b143
commit: af337b143909c9dfe1560b5005463ab44ba2548b build: 2020-09-30__19:24:38


$ r2 -av850 -b32 ired_v850
(...)
WARNING: (dwarf_process.c:852):map_dwarf_reg_to_x86_reg: code should not be reached
WARNING: (dwarf_process.c:852):map_dwarf_reg_to_x86_reg: code should not be reached
WARNING: (dwarf_process.c:852):map_dwarf_reg_to_x86_reg: code should not be reached
(...)
WARNING: r_reg_profile_to_cc: assertion 'a0' failed (line 415)
Warning: Cannot derive CC from reg profile.
Warning: Missing calling conventions for 'v850'. Deriving it from the regprofile.
WARNING: r_reg_profile_to_cc: assertion 'a0' failed (line 415)
Warning: Cannot derive CC from reg profile.
Warning: Missing calling conventions for 'v850'. Deriving it from the regprofile.
 -- Dissasemble? No dissasemble, no dissassemble!!!!!
[0x00100000]> aaaa
[x] Analyze all flags starting with sym. and entry0 (aa)
[x] Analyze function calls (aac)
[x] Analyze len bytes of instructions for references (aar)
[x] Check for vtables
[x] Finding xrefs in noncode section with anal.in=io.maps
[x] Analyze value pointers (aav)
[x] Value from 0x00117dc4 to 0x00117e38 (aav)
[x] 0x00117dc4-0x00117e38 in 0x117dc4-0x117e38 (aav)
[x] 0x00117dc4-0x00117e38 in 0x100000-0x117dc4 (aav)
[x] Value from 0x00100000 to 0x00117dc4 (aav)
[x] 0x00100000-0x00117dc4 in 0x117dc4-0x117e38 (aav)
[x] 0x00100000-0x00117dc4 in 0x100000-0x117dc4 (aav)
[Warning: No SN reg alias for current architecture.aaef)
Warning: No SN reg alias for current architecture.
Warning: No SN reg alias for current architecture.
(...)
[x] Emulate functions to find computed references (aaef)
[x] Type matching analysis for all functions (aaft)
[x] Propagate noreturn information
[x] Integrate dwarf function information.
[x] Use -AA or aaaa to perform additional experimental analysis.
[x] Finding function preludes
[x] Enable constraint types analysis for variables
[0x00100000]>
```